### PR TITLE
adding support for X-ZUMO- headers

### DIFF
--- a/AzureAppServiceAuthenticationMiddleware/AzureAppServiceAuthenticationHandler.cs
+++ b/AzureAppServiceAuthenticationMiddleware/AzureAppServiceAuthenticationHandler.cs
@@ -47,6 +47,12 @@ namespace Middleware.Authentication.AppService
                 //fetch value from endpoint
                 var request = new HttpRequestMessage(HttpMethod.Get, $"{uriString}/.auth/me");
 
+                foreach ( var header in Context.Request.Headers){
+                    if(header.Key.StartsWith("X-ZUMO-")){
+                        request.Headers.Add(header.Key,header.Value[0]);
+                    }
+                }
+
                 JArray payload = null;
 
                 using (HttpClient client = new HttpClient(handler))


### PR DESCRIPTION
accessing /.auth/me can be done with X-ZUMO- headers. without this they
will fail with 401.71 errors